### PR TITLE
Update#7

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,10 @@
 from flask import Flask, request
 # from getRequests import exact, union, intersection
-# from postRequests import add, delete
+from src.postRequests import update_doc
 
 
 app = Flask(__name__)
+
 '''
 @params: http header
 @returns: Json response with list of doc-ids, tf-idf score
@@ -11,9 +12,9 @@ app = Flask(__name__)
               match with the query
 @throws: returns with response 400 if any error occurs
 '''
-@app.route('/releventDocs', methods=['POST'])
+@app.route('/relevantDocs', methods=['POST'])
 def get_docs():
-    pass
+    return 'Todo..'
 
 # '''
 # @params: None
@@ -60,18 +61,10 @@ def get_docs():
 '''
 @app.route('/update', methods=['POST'])
 def update():
-    pass
+    params = request.args
+    json = request.json
+    return update_doc(params['docID'], json)
 
-# '''
-# @params: None
-# @returns: Json response with list of doc-ids, tf-idf score
-# @description: removes the doc-id and associated transformed text
-# @throws: returns with response 400 if any error occurs
-# '''
-# @app.route('/remove')
-# def remove_document():
-#     remove(docID)
-#     return 'Todo...'
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,8 @@ from flask import Flask, request
 # from getRequests import exact, union, intersection
 # from postRequests import add, delete
 
+
+app = Flask(__name__)
 '''
 @params: http header
 @returns: Json response with list of doc-ids, tf-idf score
@@ -9,10 +11,9 @@ from flask import Flask, request
               match with the query
 @throws: returns with response 400 if any error occurs
 '''
-@app.route('/releventDocs')
-def exact_match():
-    exact()
-    return 'Todo...'
+@app.route('/releventDocs', methods=['POST'])
+def get_docs():
+    pass
 
 # '''
 # @params: None
@@ -57,10 +58,9 @@ def exact_match():
 @description: adds the new doc-id with transformed text
 @throws: returns with response 400 if any error occurs
 '''
-@app.route('/update')
-def add_document():
-    #add(docID)
-    return 'Todo...'
+@app.route('/update', methods=['POST'])
+def update():
+    pass
 
 # '''
 # @params: None
@@ -72,3 +72,6 @@ def add_document():
 # def remove_document():
 #     remove(docID)
 #     return 'Todo...'
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/src/postRequests.py
+++ b/src/postRequests.py
@@ -1,27 +1,60 @@
-'''
-@params: parsable json object
-@returns: dictionary with data from json
-@description: creates a object from json which can be used
-              easily in python
-@throws: JsonifyError if any error occurs
-'''
-def parseJSON():
+from redis import Redis
+from flask import Response
+
+# Todo: come up with a way to save redis configuration (password) securely
+index = Redis(host='localhost', port=6379, db=0)  # k, v store for term -> doc_id
+term_positions = Redis(host='localhost', port=6379, db=1)  # k, v store for doc:term -> list of positions
+
+
+# Todo: probably remove this, Flask automatically converts json to dictionary
+def parse_json():
+    """
+    @params: parsable json object
+    @returns: dictionary with data from json
+    @description: creates a object from json which can be used
+                  easily in python
+    @throws: JsonifyError if any error occurs
+    """
     pass
 
-'''
-@params: args from http
-@returns: 200 ok if added correctly
-@description: gets all of the exact matches from index
-@throws: MatchError if any error occurs
-'''
-def add(docID):
-    pass
 
-'''
-@params: args from http
-@returns: set of doc ids
-@description: gets all of the exact matches from index
-@throws: MatchError if any error occurs
-'''
-def remove(docID):
+# Todo: implement remove_doc functionality
+def update_doc(doc_id, new_doc):
+    """
+    @param doc_id: id of document we are updating
+    @param new_doc: json of new_doc to be added to index
+    @returns: 201 status code if created successfully, 422 status code otherwise
+    @description: gets all of the exact matches from index
+    """
+    if new_doc:
+        # If there is a new doc to add, add the words and their tf scores
+        add_doc(doc_id, new_doc['grams']['1'], new_doc['total'])
+    return Response(f"Document: {doc_id}, successfully added", status=201, mimetype='application/json')
+
+
+def add_doc(doc_id, words, total):
+    """
+    @param doc_id: id of document we are adding
+    @param words: dictionary of words and their positions in the document
+    @param total: total number of words in document (used for tf calculation)
+    @description: add words in this document along with their positions to index
+    """
+    with index.pipeline() as index_pipe, term_positions.pipeline() as term_pipe:
+        for word in words:
+            # Add this word to term -> doc_id mapping
+            index_pipe.zadd(word, {doc_id: len(words[word]) / total})
+            # Update the list of positions for this word in this document (word -> list of positions)
+            term_pipe.rpush(f"{doc_id}:{word}", *words[word])
+        # Add them to redis in batch
+        index_pipe.execute()
+        term_pipe.execute()
+
+
+def remove(doc_id):
+    """
+    @params: args from http
+    @returns: set of doc ids
+    @description: gets all of the exact matches from index
+    @throws: MatchError if any error occurs
+    """
     pass


### PR DESCRIPTION
in /update the adding of documents to the index is now supported. *Note: we still need to add the remove functionality to this call.

Also, the problem of storing different types of k,v pairs in the same redis instance was solved. Redis actually supports the partitioning of up to 16 different db's in a single instance. So I made the decision to store term -> doc_id pairs in one db and doc_id:term -> list of positions in another db.

These changes were made under the assumption that our POST request body looks like this

> {

	"stripped": "ebook use anyone anywhere united States most other parts world no cost with almost no restrictions whatsoever",
	"total": 17,
	"grams": {
		"1": {
			"ebook": [0],
			"use": [1],
			"anyone": [2],
			"anywhere": [3],
			"united": [4],
			"states": [5],
			"most": [6],
			"other": [7],
			"parts": [8],
			"world": [9],
			"no": [10, 14],
			"cost": [11],
			"with": [12],
			"almost": [13],
			"restrictions": [15],
			"whatsoever": [16]
		}
	},
	"title": "Hello World"
} 