### PR TITLE
finished /update endpoint: it now removes old docs too

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/.idea/LSPT-Fall-19-IndexOfBlue.iml
+++ b/.idea/LSPT-Fall-19-IndexOfBlue.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (index)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (index)" project-jdk-type="Python SDK" />
+  <component name="PyCharmProfessionalAdvertiser">
+    <option name="shown" value="true" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/LSPT-Fall-19-IndexOfBlue.iml" filepath="$PROJECT_DIR$/.idea/LSPT-Fall-19-IndexOfBlue.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/app.py
+++ b/src/app.py
@@ -54,16 +54,14 @@ def get_docs():
 #     return 'Todo...'
 
 '''
-@params: None
-@returns: 200 ok if the document was added to the index
+@params: None, takes in body of POST
+@returns: 201 created if the document was updated successfully
 @description: adds the new doc-id with transformed text
 @throws: returns with response 400 if any error occurs
 '''
 @app.route('/update', methods=['POST'])
 def update():
-    params = request.args
-    json = request.json
-    return update_doc(params['docID'], json)
+    return update_doc(request.args['docID'], request.json['old'], request.json['new'])
 
 
 if __name__ == '__main__':

--- a/src/postRequests.py
+++ b/src/postRequests.py
@@ -6,30 +6,40 @@ index = Redis(host='localhost', port=6379, db=0)  # k, v store for term -> doc_i
 term_positions = Redis(host='localhost', port=6379, db=1)  # k, v store for doc:term -> list of positions
 
 
-# Todo: probably remove this, Flask automatically converts json to dictionary
-def parse_json():
-    """
-    @params: parsable json object
-    @returns: dictionary with data from json
-    @description: creates a object from json which can be used
-                  easily in python
-    @throws: JsonifyError if any error occurs
-    """
-    pass
-
-
-# Todo: implement remove_doc functionality
-def update_doc(doc_id, new_doc):
+def update_doc(doc_id, old_doc, new_doc):
     """
     @param doc_id: id of document we are updating
+    @param old_doc: json of old_doc to be removed from index
     @param new_doc: json of new_doc to be added to index
     @returns: 201 status code if created successfully, 422 status code otherwise
-    @description: gets all of the exact matches from index
+    @description: replaces all data from old document with that from the new document
     """
+    if old_doc:
+        remove_doc(doc_id, old_doc['grams']['1'])
     if new_doc:
         # If there is a new doc to add, add the words and their tf scores
         add_doc(doc_id, new_doc['grams']['1'], new_doc['total'])
-    return Response(f"Document: {doc_id}, successfully added", status=201, mimetype='application/json')
+    return Response(f"Document: {doc_id}, successfully updated", status=201, mimetype='application/json')
+
+
+def remove_doc(doc_id, words):
+    """
+    @param doc_id: id of document to be removed
+    @param words: words associated to this document to be removed
+    @description: removes doc_id-word associations for given doc_id and words
+    """
+    with index.pipeline() as index_pipe, term_positions.pipeline() as term_pipe:
+        for word in words:
+            # Remove id for word in word -> doc_id mapping, if word only appears in this document then remove word
+            if index.zcard(word) > 1:
+                index_pipe.zrem(word, doc_id)
+            else:
+                index_pipe.delete(word)
+            # Remove word and its associated positions within the document
+            term_pipe.delete(f"{doc_id}:{word}")
+
+        index_pipe.execute()
+        term_pipe.execute()
 
 
 def add_doc(doc_id, words, total):
@@ -48,13 +58,3 @@ def add_doc(doc_id, words, total):
         # Add them to redis in batch
         index_pipe.execute()
         term_pipe.execute()
-
-
-def remove(doc_id):
-    """
-    @params: args from http
-    @returns: set of doc ids
-    @description: gets all of the exact matches from index
-    @throws: MatchError if any error occurs
-    """
-    pass


### PR DESCRIPTION
Deleting things from the index is pretty straight-forward after figuring out how to add things. One thing I had to consider was when to delete the key, and when to delete the value that the key points to. This should be pretty straight-forward if you look at the code in delete_doc. 

Testing methodology:

I did a few postman requests with the following json. I ensured that switching the old and new tags resulted in a different index entirely (which it did). Barring any massive oversight, everything should work fine.

> {
	"old": {
		"stripped": "old text here lets delete this",
		"total": 6,
		"grams": {
			"1": {
				"old": [0],
				"text": [1],
				"here": [2],
				"lets": [3],
				"delete": [4],
				"this": [5]
			}
		}
	},
	"new": {
		"stripped": "ebook use anyone anywhere united States most other parts world no cost with almost no restrictions whatsoever",
		"total": 17,
		"grams": {
			"1": {
				"ebook": [0],
				"use": [1],
				"anyone": [2],
				"anywhere": [3],
				"united": [4],
				"states": [5],
				"most": [6],
				"other": [7],
				"parts": [8],
				"world": [9],
				"no": [10, 14],
				"cost": [11],
				"with": [12],
				"almost": [13],
				"restrictions": [15],
				"whatsoever": [16]
			}
		},
		"title": "Hello World"
	}
}