### PR TITLE
Fixed case when attempting to add word without a list of positions

### DIFF
--- a/indexapp/update.py
+++ b/indexapp/update.py
@@ -17,8 +17,9 @@ def update_doc(app, doc_id, old_doc, new_doc):
     @description: replaces all data from old document with that from the new document
     """
     old_doc_valid = 'grams' in old_doc and '1' in old_doc['grams']
-    new_doc_valid = 'grams' in new_doc and '1' in new_doc['grams'] and 'total' in new_doc
-    
+    new_doc_valid = 'grams' in new_doc and '1' in new_doc['grams'] and 'total' \
+                    in new_doc
+
     if old_doc_valid:
         remove_doc(app, doc_id, old_doc['grams']['1'])
         if not new_doc_valid:
@@ -26,15 +27,22 @@ def update_doc(app, doc_id, old_doc, new_doc):
 
     if new_doc_valid:
         # If there is a new doc to add, add the words and their tf scores
-        add_doc(app, doc_id, new_doc['grams']['1'], new_doc['total'])
+        try:
+            add_doc(app, doc_id, new_doc['grams']['1'], new_doc['total'])
+        # If there is an error in the format of the request body, return a 400
+        except ValueError as error:
+            return Response(error.args[0], status=400, mimetype='application/json')
         if not old_doc_valid:
             app.index.incr('total_docs')
 
     # If there is nothing to add or remove, return a 400 for bad format
     if not new_doc_valid and not old_doc_valid:
-        return Response("Invalid Format, nothing to add or remove", status=400, mimetype='application/json')
+        return Response("Invalid Format, nothing to add or remove", status=400,
+                        mimetype='application/json')
 
-    return Response(f"Document: {doc_id}, successfully updated", status=201, mimetype='application/json')
+    # Successful response if no issues raised
+    return Response(f"Document: {doc_id}, successfully updated", status=201,
+                    mimetype='application/json')
 
 
 def remove_doc(app, doc_id, words):
@@ -44,9 +52,11 @@ def remove_doc(app, doc_id, words):
     @param words: words associated to this document to be removed
     @description: removes doc_id-word associations for given doc_id and words
     """
-    with app.index.pipeline() as index_pipe, app.term_positions.pipeline() as term_pipe:
+    with app.index.pipeline() as index_pipe, app.term_positions.pipeline() as \
+            term_pipe:
         for word in words:
-            # Remove id for word in word -> doc_id mapping, if word only appears in this document then remove word
+            # Remove id for word in word -> doc_id mapping, if word only
+            # appears in this document then remove word
             if app.index.exists(word):
                 if app.index.zcard(word) > 1:
                     index_pipe.zrem(word, doc_id)
@@ -66,14 +76,23 @@ def add_doc(app, doc_id, words, total):
     @param doc_id: id of document we are adding
     @param words: dictionary of words and their positions in the document
     @param total: total number of words in document (used for tf calculation)
-    @description: add words in this document along with their positions to index
+    @throws ValueError if a word with no positions list is added
+    @description: add words in this document along with their positions to
+    index
     """
-    with app.index.pipeline() as index_pipe, app.term_positions.pipeline() as term_pipe:
+    with app.index.pipeline() as index_pipe, app.term_positions.pipeline() \
+            as term_pipe:
         for word in words:
-            # Add this word to term -> doc_id mapping
-            index_pipe.zadd(word, {doc_id: len(words[word]) / total})
-            # Update the list of positions for this word in this document (word -> list of positions)
-            term_pipe.rpush(f"{doc_id}:{word}", *words[word])
+            # If there is no list of positions, this is in an invalid format.
+            # Return 400 bad request
+            if len(words[word]) > 0:
+                # Add this word to term -> doc_id mapping
+                index_pipe.zadd(word, {doc_id: len(words[word]) / total})
+                # Update the list of positions for this word in this document
+                # (word -> list of positions)
+                term_pipe.rpush(f"{doc_id}:{word}", *words[word])
+            else:
+                raise ValueError(f"term: {word}, does not contain list of positions")
         # Add them to redis in batch
         index_pipe.execute()
         term_pipe.execute()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -46,7 +46,8 @@ def test_bad_update(client):
     update = client.post('/update?docID=1', json=json_data)
 
     assert update.status_code == 400
-    
+
+
 def test_bad_update_no_occurrences(client):
     """
     This test ensures the correct http status code is returned for a mis-formatted
@@ -72,6 +73,7 @@ def test_blank_update(client):
 
     assert update.status_code == 400
 
+
 def test_invalid_remove(client):
     """
     A request that attempts to remove words that do not exist.
@@ -83,6 +85,7 @@ def test_invalid_remove(client):
     update = client.post('/update?docID=1', json=json_data)
 
     assert update.status_code == 201
+
 
 def test_basic_retrieve(client):
     """

--- a/test/test_correctness.py
+++ b/test/test_correctness.py
@@ -30,8 +30,7 @@ def make_mock(client):
     for i in range(6):
         json_file = open(f"../test/test_docs/doc{i + 1}.json")
         json_data = json.load(json_file)
-        post = client.post(f"/update?docID={i + 1}", json=json_data)
-        print(post.status_code)
+        client.post(f"/update?docID={i + 1}", json=json_data)
 
 
 def test_single_doc(client):


### PR DESCRIPTION
So I ran the tests locally and realized we were failing for the case when an update call is made with an empty list of positions for a term. I updated the update functions to throw an error and return a 400 response when this happens.

Also made some changes to ensure pep8 is being followed